### PR TITLE
reduce scope to focus on api lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python Version](https://img.shields.io/pypi/pyversions/booxdrop.svg)](https://pypi.org/project/booxdrop/)
 [![License](https://img.shields.io/pypi/l/booxdrop.svg)](https://github.com/filipgodlewski/pyBooxDrop/blob/main/LICENSE)
 
-A simple, unofficial Python library and CLI for Onyx BooxDrop.
+A simple, unofficial Python API library for Onyx BooxDrop.
 If you’re not a fan of the official app,
 here’s a cleaner, modern, and easy-to-use alternative —
 perfect for managing your books on your Boox device.
@@ -13,7 +13,6 @@ perfect for managing your books on your Boox device.
 ## Features
 
 - Standardized and organized API client for BooxDrop
-- Easy-to-use CLI tool `boox` for interacting with the API
 - Fully typed with `pydantic` and type hints
 - Open source, modern Python 3.12+ support
 
@@ -27,25 +26,7 @@ perfect for managing your books on your Boox device.
 pip install pybooxdrop
 ```
 
-Or install CLI globally with pipx:
-
-```bash
-pipx install pybooxdrop
-```
-
 ## Usage
-
-### CLI
-
-Basic usage:
-
-```bash
-boox --help
-
-# TODO: output
-```
-
-### Python API
 
 Basic example of using the library:
 
@@ -67,7 +48,7 @@ Contributions are welcome!
 Big thanks to [hrw](https://github.com/hrw)
 and their project [onyx-send2boox](https://github.com/hrw/onyx-send2boox).
 Their work was the main inspiration behind this tool.
-While pyBooxDrop is a fresh, focused take on just the API and CLI,
+While pyBooxDrop is a fresh, focused take on just the API,
 this project wouldn’t exist without their awesome groundwork.
 
 Thanks for the great job!


### PR DESCRIPTION
I decided that it would rather be a bad idea to include too many tools
in one. Let this project be only for api. I already have ideas for a
separate CLI tool that would use this lib.
